### PR TITLE
Honor CORS_ORIGIN

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,6 +8,9 @@ ADMIN_PASS=your_admin_password
 # JWT 签名密钥
 JWT_SECRET=your_jwt_secret
 
+# 允许的跨域来源（逗号分隔，留空或填 * 允许全部）
+CORS_ORIGIN=https://example.com
+
 # 邮件服务（QQ 邮箱示例）
 SMTP_HOST=smtp.qq.com
 SMTP_PORT=465

--- a/backend/server.js
+++ b/backend/server.js
@@ -42,7 +42,8 @@ app.use((req, res, next) => {
 
 console.log('CORS_ORIGIN=', process.env.CORS_ORIGIN);
 // CORS
-app.use(cors());
+const corsOrigin = !CORS_ORIGIN || CORS_ORIGIN === '*' ? '*' : CORS_ORIGIN.split(',').map(o => o.trim());
+app.use(cors({ origin: corsOrigin }));
 
 
 // Body parser


### PR DESCRIPTION
## Summary
- control CORS via `CORS_ORIGIN` env variable
- document CORS_ORIGIN format in backend env example

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684e750420e0832e88fd59c5028c8ef4